### PR TITLE
Change psycopg2-binary requirement to psycopg2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
 ]
 dependencies = [
-  "psycopg2-binary",
+  "psycopg2==2.9.10",
   "rda-python-globus",
   "unidecode"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rda_python_common"
-version = "2.1.5"
+version = "2.1.6"
 authors = [
   { name="Zaihua Ji", email="zji@ucar.edu" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 iniconfig==2.1.0
 packaging==24.2
 pluggy==1.5.0
-psycopg2-binary==2.9.10
+psycopg2==2.9.10
 pytest==8.3.5
 rda-python-globus
 unidecode


### PR DESCRIPTION
This pull request makes a small update to the dependencies in `pyproject.toml`, specifying an exact version for the `psycopg2` package instead of using `psycopg2-binary`. This change helps ensure consistent behavior across different environments.